### PR TITLE
Fix execution of subprocess.Popen()

### DIFF
--- a/op_blender_rhubarb.py
+++ b/op_blender_rhubarb.py
@@ -99,14 +99,18 @@ class RhubarbLipsyncOperator(bpy.types.Operator):
 
         inputfile = bpy.path.abspath(context.object.pose_library.mouth_shapes.sound_file)
         dialogfile = bpy.path.abspath(context.object.pose_library.mouth_shapes.dialog_file)
+        executable = bpy.path.abspath(addon_prefs.executable_path)
+        
+        command = [executable, "-f", "json", "--machineReadable", "--extendedShapes", "GHX", inputfile]
+        
         if dialogfile:
-            dialog = "--dialogFile %s" % dialogfile
+            command.append("--dialogFile")
+            command.append(dialogfile)
         else:
             dialog = ""
-
-        executable = bpy.path.abspath(addon_prefs.executable_path)
-        self.rhubarb = subprocess.Popen("%s -f json --machineReadable %s --extendedShapes GHX %s"
-                                        % (executable, dialog, inputfile),
+        
+        
+        self.rhubarb = subprocess.Popen(command,
                                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 
         wm = context.window_manager


### PR DESCRIPTION
As outlined in https://docs.python.org/3/library/subprocess.html#subprocess.Popen -
"args should be a sequence of program arguments or else a single string. By default, the program to execute is the first item in args if args is a sequence. If args is a string, the interpretation is platform-dependent."

This commit turns args into a sequence, which makes the plugin work correctly on POSIX systems (Linux/OSX).