### PR TITLE
Allow to call operator from other python scripts

### DIFF
--- a/op_blender_rhubarb.py
+++ b/op_blender_rhubarb.py
@@ -116,7 +116,8 @@ class RhubarbLipsyncOperator(bpy.types.Operator):
 
         return {'RUNNING_MODAL'}
 
-
+    def execute(self, context):
+        return self.invoke(context, None)
 
     def finished(self, context):
         wm = context.window_manager


### PR DESCRIPTION
Allow to call operator from other python scripts using this: "bpy.ops.object.rhubarb_lipsync()".

This is needed for automating some operations. I.e. I have a script, which  parses each blender file, sets parameters for lipsync and executes lipsync operation.

Without this fix the attempt to call it gives following error: "wm_operator_invoke: invalid operator call 'OBJECT_OT_rhubarb_lipsync'".